### PR TITLE
Feat: relocate request

### DIFF
--- a/internal/cmd/generate.go
+++ b/internal/cmd/generate.go
@@ -31,7 +31,7 @@ type GenerateCommand struct {
 	flagOutputPath string
 }
 
-type SpecificationWithSDK struct {
+type NcloudSpecification struct {
 	spec.Specification
 	Resources   []mapper.DetailResourceInfo   `json:"resources"`
 	DataSources []mapper.DetailDataSourceInfo `json:"datasources"`
@@ -194,7 +194,7 @@ func (cmd *GenerateCommand) runInternal(logger *slog.Logger) error {
 	return nil
 }
 
-func generateProviderCodeSpec(logger *slog.Logger, dora explorer.Explorer, cfg config.Config) (*SpecificationWithSDK, error) {
+func generateProviderCodeSpec(logger *slog.Logger, dora explorer.Explorer, cfg config.Config) (*NcloudSpecification, error) {
 	// 1. Find TF resources in OAS
 	explorerResources, err := dora.FindResources()
 	if err != nil {
@@ -234,7 +234,7 @@ func generateProviderCodeSpec(logger *slog.Logger, dora explorer.Explorer, cfg c
 		return nil, fmt.Errorf("error generating provider code spec for provider: %w", err)
 	}
 
-	return &SpecificationWithSDK{
+	return &NcloudSpecification{
 		Specification: spec.Specification{
 			Version: spec.Version0_1,
 		},

--- a/internal/cmd/generate.go
+++ b/internal/cmd/generate.go
@@ -33,10 +33,10 @@ type GenerateCommand struct {
 
 type SpecificationWithSDK struct {
 	spec.Specification
-	Provider    *mapper.ProviderWithEndpoint  `json:"provider"`
 	Requests    []mapper.Request              `json:"requests"`
 	Resources   []mapper.DetailResourceInfo   `json:"resources"`
 	DataSources []mapper.DetailDataSourceInfo `json:"datasources"`
+	Provider    *mapper.ProviderWithEndpoint  `json:"provider"`
 }
 
 func (cmd *GenerateCommand) Flags() *flag.FlagSet {
@@ -235,17 +235,10 @@ func generateProviderCodeSpec(logger *slog.Logger, dora explorer.Explorer, cfg c
 		return nil, fmt.Errorf("error generating provider code spec for provider: %w", err)
 	}
 
-	requestMapper := mapper.NewRequestMapper(explorerResources, explorerDataSources, cfg)
-	requestsIR, err := requestMapper.MapToIR(logger)
-	if err != nil {
-		return nil, fmt.Errorf("error generating provider code spec for request: %w", err)
-	}
-
 	return &SpecificationWithSDK{
 		Specification: spec.Specification{
 			Version: spec.Version0_1,
 		},
-		Requests:    requestsIR,
 		Provider:    providerIR,
 		Resources:   resourcesIR,
 		DataSources: dataSourcesIR,

--- a/internal/cmd/generate.go
+++ b/internal/cmd/generate.go
@@ -33,7 +33,6 @@ type GenerateCommand struct {
 
 type SpecificationWithSDK struct {
 	spec.Specification
-	Requests    []mapper.Request              `json:"requests"`
 	Resources   []mapper.DetailResourceInfo   `json:"resources"`
 	DataSources []mapper.DetailDataSourceInfo `json:"datasources"`
 	Provider    *mapper.ProviderWithEndpoint  `json:"provider"`

--- a/internal/mapper/datasource_mapper.go
+++ b/internal/mapper/datasource_mapper.go
@@ -27,7 +27,7 @@ type DataSourceMapper interface {
 
 type DetailDataSourceInfo struct {
 	datasource.DataSource
-	Requests            CRUDParameters `json:"requests"`
+	CRUDParameters      CRUDParameters `json:"crud_parameters"`
 	RefreshObjectName   string         `json:"refresh_object_name"`
 	ImportStateOverride string         `json:"import_state_override"`
 	Id                  string         `json:"id"`
@@ -95,7 +95,7 @@ func (m dataSourceMapper) MapToIR(logger *slog.Logger) ([]DetailDataSourceInfo, 
 				Name:   name,
 				Schema: schema,
 			},
-			Requests:            datasourceRequestIR,
+			CRUDParameters:      datasourceRequestIR,
 			RefreshObjectName:   refreshObjectName,
 			ImportStateOverride: importStateOverride,
 			Id:                  id,

--- a/internal/mapper/datasource_request_mapper.go
+++ b/internal/mapper/datasource_request_mapper.go
@@ -1,0 +1,69 @@
+package mapper
+
+import (
+	"log/slog"
+
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-openapi/internal/config"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-openapi/internal/explorer"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-openapi/internal/log"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-openapi/internal/mapper/oas"
+	"github.com/NaverCloudPlatform/terraform-plugin-codegen-spec/spec"
+)
+
+var _ RequestMapper = datasourceRequestMapper{}
+
+type datasourceRequestMapper struct {
+	datasource explorer.DataSource
+	name       string
+	cfg        config.Config
+}
+
+func NewDataSourceRequestMapper(datasource explorer.DataSource, name string, cfg config.Config) datasourceRequestMapper {
+	return datasourceRequestMapper{
+		datasource: datasource,
+		name:       name,
+		cfg:        cfg,
+	}
+}
+
+func (m datasourceRequestMapper) MapToIR(logger *slog.Logger) (CRUDParameters, error) {
+	rLogger := logger.With("request", m.name)
+
+	requestType, err := generateRequestDataSourceType(rLogger, m.datasource, m.name, m.cfg)
+	if err != nil {
+		log.WarnLogOnError(rLogger, err, "skipping resource request type mapping")
+	}
+
+	return requestType, nil
+}
+
+func generateRequestDataSourceType(logger *slog.Logger, explorerDataSource explorer.DataSource, name string, config config.Config) (CRUDParameters, error) {
+	schemaOpts := oas.SchemaOpts{
+		Ignores: explorerDataSource.SchemaOptions.Ignores,
+	}
+
+	logger.Debug("searching for read operation parameters and request body")
+	requestBody, err := extractRequestBody(explorerDataSource.ReadOp, schemaOpts)
+	if err != nil {
+		log.WarnLogOnError(logger, err, "skipping mapping of read operation request body")
+	}
+	response, err := extractResponse(explorerDataSource.ReadOp, schemaOpts)
+	if err != nil {
+		log.WarnLogOnError(logger, err, "skipping mappin gof read operation response")
+	}
+	readRequest := NcloudCommonRequestType{
+		DetailedRequestType: DetailedRequestType{
+			RequestType: spec.RequestType{
+				Response: response,
+			},
+			Parameters:  extractParametersInfo(explorerDataSource.ReadOp),
+			RequestBody: requestBody,
+		},
+		Method: config.DataSources[name].Read.Method,
+		Path:   config.DataSources[name].Read.Path,
+	}
+
+	return CRUDParameters{
+		Read: readRequest,
+	}, nil
+}

--- a/internal/mapper/datasource_request_mapper.go
+++ b/internal/mapper/datasource_request_mapper.go
@@ -64,6 +64,6 @@ func generateRequestDataSourceType(logger *slog.Logger, explorerDataSource explo
 	}
 
 	return CRUDParameters{
-		Read: readRequest,
+		Read: &readRequest,
 	}, nil
 }

--- a/internal/mapper/request_mapper.go
+++ b/internal/mapper/request_mapper.go
@@ -27,7 +27,7 @@ type NcloudCommonRequestType struct {
 	Path   string `json:"path,omitempty"`
 }
 
-type RequestOperations struct {
+type CRUDParameters struct {
 	Create NcloudCommonRequestType    `json:"create,omitempty"`
 	Read   NcloudCommonRequestType    `json:"read,omitempty"`
 	Update []*NcloudCommonRequestType `json:"update,omitempty"`
@@ -35,7 +35,7 @@ type RequestOperations struct {
 }
 
 type Request struct {
-	RequestOperations
+	CRUDParameters
 	Name string `json:"name,omitempty"`
 }
 
@@ -205,7 +205,7 @@ func generateRequestType(logger *slog.Logger, explorerResource explorer.Resource
 
 	return Request{
 		Name: name,
-		RequestOperations: RequestOperations{
+		CRUDParameters: CRUDParameters{
 			Create: createRequest,
 			Read:   readRequest,
 			Update: updateRequest,
@@ -242,7 +242,7 @@ func generateRequestDataSourceType(logger *slog.Logger, explorerDataSource explo
 
 	return Request{
 		Name: name,
-		RequestOperations: RequestOperations{
+		CRUDParameters: CRUDParameters{
 			Read: readRequest,
 		},
 	}, nil

--- a/internal/mapper/resource_mapper.go
+++ b/internal/mapper/resource_mapper.go
@@ -26,9 +26,10 @@ type ResourceMapper interface {
 
 type DetailResourceInfo struct {
 	resource.Resource
-	RefreshObjectName   string `json:"refresh_object_name"`
-	ImportStateOverride string `json:"import_state_override"`
-	Id                  string `json:"id"`
+	Requests            CRUDParameters `json:"requests"`
+	RefreshObjectName   string         `json:"refresh_object_name"`
+	ImportStateOverride string         `json:"import_state_override"`
+	Id                  string         `json:"id"`
 }
 
 type resourceMapper struct {
@@ -54,6 +55,13 @@ func (m resourceMapper) MapToIR(logger *slog.Logger) ([]DetailResourceInfo, erro
 		rLogger := logger.With("resource", name)
 		id := m.cfg.Resources[name].Id
 		importStateOverride := m.cfg.Resources[name].ImportStateOverride
+
+		requestMapper := NewResourceRequestMapper(explorerResource, name, m.cfg)
+		resourceRequestIR, err := requestMapper.MapToIR(logger)
+		if err != nil {
+			log.WarnLogOnError(rLogger, err, "skipping resource request mapping")
+			continue
+		}
 
 		var refreshObjectName string
 		t := m.cfg.Resources[name].RefreshObjectName
@@ -86,6 +94,7 @@ func (m resourceMapper) MapToIR(logger *slog.Logger) ([]DetailResourceInfo, erro
 				Name:   name,
 				Schema: schema,
 			},
+			Requests:            resourceRequestIR,
 			RefreshObjectName:   refreshObjectName,
 			ImportStateOverride: importStateOverride,
 			Id:                  id,

--- a/internal/mapper/resource_mapper.go
+++ b/internal/mapper/resource_mapper.go
@@ -26,7 +26,7 @@ type ResourceMapper interface {
 
 type DetailResourceInfo struct {
 	resource.Resource
-	Requests            CRUDParameters `json:"requests"`
+	CRUDParameters      CRUDParameters `json:"crud_parameters"`
 	RefreshObjectName   string         `json:"refresh_object_name"`
 	ImportStateOverride string         `json:"import_state_override"`
 	Id                  string         `json:"id"`
@@ -94,7 +94,7 @@ func (m resourceMapper) MapToIR(logger *slog.Logger) ([]DetailResourceInfo, erro
 				Name:   name,
 				Schema: schema,
 			},
-			Requests:            resourceRequestIR,
+			CRUDParameters:      resourceRequestIR,
 			RefreshObjectName:   refreshObjectName,
 			ImportStateOverride: importStateOverride,
 			Id:                  id,

--- a/internal/mapper/resource_request_mapper.go
+++ b/internal/mapper/resource_request_mapper.go
@@ -34,6 +34,11 @@ type CRUDParameters struct {
 	Delete NcloudCommonRequestType    `json:"delete,omitempty"`
 }
 
+type Request struct {
+	CRUDParameters
+	Name string `json:"name,omitempty"`
+}
+
 type resourceRequestMapper struct {
 	resource explorer.Resource
 	name     string

--- a/internal/mapper/resource_request_mapper.go
+++ b/internal/mapper/resource_request_mapper.go
@@ -28,15 +28,10 @@ type NcloudCommonRequestType struct {
 }
 
 type CRUDParameters struct {
-	Create NcloudCommonRequestType    `json:"create,omitempty"`
-	Read   NcloudCommonRequestType    `json:"read,omitempty"`
+	Create *NcloudCommonRequestType   `json:"create,omitempty"`
+	Read   *NcloudCommonRequestType   `json:"read,omitempty"`
 	Update []*NcloudCommonRequestType `json:"update,omitempty"`
-	Delete NcloudCommonRequestType    `json:"delete,omitempty"`
-}
-
-type Request struct {
-	CRUDParameters
-	Name string `json:"name,omitempty"`
+	Delete *NcloudCommonRequestType   `json:"delete,omitempty"`
 }
 
 type resourceRequestMapper struct {
@@ -180,10 +175,10 @@ func generateResourceRequestType(logger *slog.Logger, explorerResource explorer.
 	}
 
 	return CRUDParameters{
-		Create: createRequest,
-		Read:   readRequest,
+		Create: &createRequest,
+		Read:   &readRequest,
 		Update: updateRequest,
-		Delete: deleteRequest,
+		Delete: &deleteRequest,
 	}, nil
 }
 


### PR DESCRIPTION
- Divide `request_mapper.go` into two filed based on source type
- Move request schema into each resource & data source
- Change output name (`requests` => `crud_parameters`)